### PR TITLE
Pin AGP back to 9.1.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.4.0"
+agp = "9.1.1"
 androidx-activityCompose = "1.13.0"
 androidx-ui-tooling = "1.12.1"
 coil = "3.5.0"

--- a/renovate.json
+++ b/renovate.json
@@ -7,9 +7,8 @@
     {
       "description": "AGP 9.3.x+ outruns what the locally installed Android Studio supports — sync fails with unsupported-AGP-version and \"could not find compile target\" errors. Hold AGP updates until Studio's bundled support catches up.",
       "matchPackageNames": [
-        "agp",
         "com.android.tools.build:gradle",
-        "/^com\\.android\\.(application|library|test|dynamic-feature|kotlin\\.multiplatform\\.library|lint)$/"
+        "/^com\\.android\\.[a-z.]+:com\\.android\\.[a-z.]+\\.gradle\\.plugin$/"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Summary

Restores AGP to the held 9.1.1 (was `9.4.0`). AGP updates are supposed to be held at 9.1.x until Android Studio's bundled AGP support catches up, but Renovate's package rule never matched the Maven coordinate, so the bumps were raised and merged by mistake.

## Test plan

- [ ] CI green
- [ ] Android app builds and runs
- [ ] Android Studio sync succeeds